### PR TITLE
feat: Change pacman starting coordinates

### DIFF
--- a/pacman.py
+++ b/pacman.py
@@ -4,7 +4,7 @@ Exercises
 
 1. Change the board. DONE
 2. Change the number of ghosts. DONE
-3. Change where pacman starts.
+3. Change where pacman starts. DONE
 4. Make the ghosts faster/slower.
 5. Make the ghosts smarter.
 """
@@ -21,7 +21,7 @@ state = {'score': 0}
 path = Turtle(visible=False)
 writer = Turtle(visible=False)
 aim = vector(5, 0)
-pacman = vector(-40, -80)
+pacman = vector(80, 80)
 ghosts = [
     [vector(-180, 160), vector(5, 0)],
     [vector(-180, -160), vector(0, 5)],


### PR DESCRIPTION
This pull request changes the starting coordinates of pacman in the game. Previously, pacman started at (-40, -80), but now it will start at (80, 80). This change ensures that pacman starts at a more strategic position condisering the new board.